### PR TITLE
Change the javascript-core required library to @abstractapi/javascript-core

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.AbstractIpGeolocation = void 0;
 
-var core = _interopRequireWildcard(require("javascript-core"));
+var core = _interopRequireWildcard(require("@abstractapi/javascript-core"));
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function _getRequireWildcardCache() { return cache; }; return cache; }
 


### PR DESCRIPTION
I noticed the required `javascript-core` library was mispelled.
